### PR TITLE
Add OSS Night

### DIFF
--- a/styles/blocks/base/xs.css
+++ b/styles/blocks/base/xs.css
@@ -32,12 +32,6 @@ h1, h2  {
   text-align: center;
 }
 
-ul, li {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
 /*
  * Cross-cutting shared classes
  */

--- a/styles/blocks/oss-night/md.css
+++ b/styles/blocks/oss-night/md.css
@@ -1,0 +1,6 @@
+@media (min-width: $md) {
+
+  #section-subtle-highlight {
+    margin-top: 40px;
+  }
+}

--- a/styles/blocks/oss-night/xs.css
+++ b/styles/blocks/oss-night/xs.css
@@ -1,18 +1,9 @@
-#marquee-container {
-  text-align: center;
-}
-
-#marquee {
-  max-width: 400px;
-  width: 100%;
-}
-
-#about-tickets-sale {
-  margin-left: 40%;
+#register-oss-night {
+  margin-left: 33%;
   margin-bottom: 40px;
   border: 3px solid $empire_yellow;
   padding: 15px 0px 0px 25px;
-  width: 240px;
+  width: 383px;
   height: 50px;
   text-transform: uppercase;
   letter-spacing: 4px;
@@ -25,7 +16,36 @@
   }
 }
 
+#event-style {
+  font-style: italic;
+  padding-top: 20px;
+}
+
+.p-oss-night {
+  padding-top: 30px;
+}
+
+#horizontal-dotted-line {
+  border-bottom: 2px dotted $empire_yellow;
+}
+
+ul {
+  list-style-type: square;
+  padding-bottom: 20px;
+}
+
 code {
   color: $empire_orange;
   background-color: rgba(241, 174, 50, 0.10);
+}
+
+#venue-box {
+  background-color: $empire_orange;
+  padding-bottom: 20px;
+  padding-left: 35px;
+
+  h3 {
+    text-align: center;
+    margin-left: -20px;
+  }
 }

--- a/styles/blocks/oss-night/xs.css
+++ b/styles/blocks/oss-night/xs.css
@@ -1,0 +1,31 @@
+#marquee-container {
+  text-align: center;
+}
+
+#marquee {
+  max-width: 400px;
+  width: 100%;
+}
+
+#about-tickets-sale {
+  margin-left: 40%;
+  margin-bottom: 40px;
+  border: 3px solid $empire_yellow;
+  padding: 15px 0px 0px 25px;
+  width: 240px;
+  height: 50px;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  overflow: hidden;
+  cursor: pointer;
+  position: relative;
+
+  span {
+    font-weight: bold;
+  }
+}
+
+code {
+  color: $empire_orange;
+  background-color: rgba(241, 174, 50, 0.10);
+}

--- a/styles/blocks/schedule/xs.css
+++ b/styles/blocks/schedule/xs.css
@@ -2,6 +2,12 @@
   background-color: #fff9ca;
   padding-bottom: 30px;
 
+  ul, li {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
   .event-schedule-body {
     margin-left: 0;
 

--- a/styles/blocks/speakers/xs.css
+++ b/styles/blocks/speakers/xs.css
@@ -1,5 +1,6 @@
 #section-speakers {
   text-align: center;
+  background-color: #fff9ca;
 }
 
 #speaker-list {

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -3,6 +3,7 @@
 {{> about }}
 {{> map }}
 {{> speakers }}
+{{> oss-night }}
 {{> schedule }}
 {{!> emcees }}
 {{!> hotel }}

--- a/views/partials/navigation.hbs
+++ b/views/partials/navigation.hbs
@@ -18,6 +18,7 @@
                 <ul class="nav navbar-nav">
                   <li><a id="nav-link-tickets" href="https://tito.io/empirejs/empirejs-2016" target="_blank">Tickets</a></li>
                   <li><a href="#venue">Venue</a></li>
+                  <li><a href="#oss-night">OSS Night</a></li>
                   <li><a href="#schedule">Schedule</a></li>
                   <li><a href="#speakers">Speakers</a></li>
                   {{!-- <li><a href="#hotel">Hotel</a></li> --}}

--- a/views/partials/oss-night.hbs
+++ b/views/partials/oss-night.hbs
@@ -1,0 +1,74 @@
+<section id="section-subtle-highlight" class="container full-width section section-event-info bg-white">
+
+  <div class="row">
+
+    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 col-xl-12">
+
+      <div class="icon-container event-icon-container">
+        <i class="fa fa-info"></i>
+      </div>
+
+      <h2>EmpireJS' inaugural OSS Night!</h2>
+      <div class="divider-inner"></div>
+
+    </div>
+
+  </div>
+
+  <div class="row">
+    <div id="about-tickets-sale">
+      <span><a href="https://ti.to/empirejs/empirejs-2016" target="_blank">Register for OSS Night!</a></span>
+    </div>
+  </div>
+
+  <div class="row">
+
+    <div class="col-xs-12 col-sm-12 col-md-10 col-lg-10 col-xl-10">
+      <p>A chicken in every pot, and a commit in every repo!</p>
+
+      <p>The EmpireJS team is excited to open up our inaugural open source night in JavaScript!
+      <p>You know those docs you reference on a daily basis? Those packages you are wiring up together to make all those websites and apps running? They were all written by volunteers like yourself.
+      Join us for an evening of learning how to contribute to docs, code, and community collaboration through open source contributions. We’ll have mentors in house with endless amounts of encouragement and insight. Every level of programmer is welcome and we’ll have groups to help make everyone feel comfortable at the pace they’d like to move.</p>
+
+      <p>This is a small groups workshop-style event. It would be helpful to be familiar with HTML, CSS and/or JavaScript.</p>
+
+      <p>Our mentors will help walk you through ways to contribute to the awesome projects you use like:</p>
+      <ul>
+        <li>Fixing bugs</li>
+        <li>Adding a feature</li>
+        <li>Writing tests</li>
+        <li>Documentation</li>
+        <li>Adding resources</li>
+        <li>Writing guides</li>
+      </ul>
+
+      <p>Please bring:</p>
+      <ul>
+        <li>An open mind</li>
+        <li>A computer with your github account dsetup https://github.com/join</li>
+        <li>Song requests (gotta keep the party going! background music!)</li>
+      </ul>
+
+      <p>Are you on open source maintainer who would love more contributors to your project? Been itching to try mentoring? Please register at the event link above or reach out to us at <a href="mailto:us@empirejs.org" target="_top">us@empirejs.org</a>!</p>
+
+      <p>A preview of  groups we’ll be diving into:</p>
+      <ul>
+        <li>StructureJS: Real-time data store & API powered by NodeJS and RethinkDB</li>
+        <li>Forever https://github.com/foreverjs/forever</li>
+        <li>Getting started in open source</li>
+        <li>jQuery</li>
+        <li>Contributing to Node.js</li>
+        <li>More to come!</li>
+      </ul>
+
+
+    </div>
+
+    <div id="marquee-container" class="col-xs-12 col-sm-12 col-md-2 col-lg-2 col-xl-2">
+      <h3>7pm to 10pm</h3>
+      <p>OSS Night at Conde Nast</p>
+      <p>222 Broadway</p>
+      <p>New York, NY 10038</p>
+    </div>
+
+</section>

--- a/views/partials/oss-night.hbs
+++ b/views/partials/oss-night.hbs
@@ -1,6 +1,6 @@
 <section id="section-subtle-highlight" class="container full-width section section-event-info bg-white">
 
-  <div class="row">
+  <div id="oss-night" class="row">
 
     <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 col-xl-12">
 

--- a/views/partials/oss-night.hbs
+++ b/views/partials/oss-night.hbs
@@ -16,23 +16,22 @@
   </div>
 
   <div class="row">
-    <div id="about-tickets-sale">
-      <span><a href="https://ti.to/empirejs/empirejs-2016" target="_blank">Register for OSS Night!</a></span>
+    <div id="register-oss-night">
+      <span><a href="https://ti.to/empirejs/empirejs-2016" target="_blank">Register as student|mentor</a></span>
     </div>
   </div>
 
   <div class="row">
 
     <div class="col-xs-12 col-sm-12 col-md-10 col-lg-10 col-xl-10">
-      <p>A chicken in every pot, and a commit in every repo!</p>
+      <p><strong>A chicken in every pot, and a commit in every repo!</strong> The EmpireJS team is excited to open up our inaugural open source night in JavaScript!
 
-      <p>The EmpireJS team is excited to open up our inaugural open source night in JavaScript!
       <p>You know those docs you reference on a daily basis? Those packages you are wiring up together to make all those websites and apps running? They were all written by volunteers like yourself.
       Join us for an evening of learning how to contribute to docs, code, and community collaboration through open source contributions. We’ll have mentors in house with endless amounts of encouragement and insight. Every level of programmer is welcome and we’ll have groups to help make everyone feel comfortable at the pace they’d like to move.</p>
 
-      <p>This is a small groups workshop-style event. It would be helpful to be familiar with HTML, CSS and/or JavaScript.</p>
+      <p id="event-style">This is a small groups workshop-style event. It would be helpful to be familiar with HTML, CSS and/or JavaScript.</p>
 
-      <p>Our mentors will help walk you through ways to contribute to the awesome projects you use like:</p>
+      <p class="p-oss-night">Our mentors will help walk you through ways to contribute to the awesome projects you use like:</p>
       <ul>
         <li>Fixing bugs</li>
         <li>Adding a feature</li>
@@ -42,33 +41,25 @@
         <li>Writing guides</li>
       </ul>
 
-      <p>Please bring:</p>
+      <div id="horizontal-dotted-line"></div>
+
+      <p class="p-oss-night">Please bring:</p>
       <ul>
         <li>An open mind</li>
         <li>A computer with your github account dsetup https://github.com/join</li>
         <li>Song requests (gotta keep the party going! background music!)</li>
       </ul>
 
-      <p>Are you on open source maintainer who would love more contributors to your project? Been itching to try mentoring? Please register at the event link above or reach out to us at <a href="mailto:us@empirejs.org" target="_top">us@empirejs.org</a>!</p>
-
-      <p>A preview of  groups we’ll be diving into:</p>
-      <ul>
-        <li>StructureJS: Real-time data store & API powered by NodeJS and RethinkDB</li>
-        <li>Forever https://github.com/foreverjs/forever</li>
-        <li>Getting started in open source</li>
-        <li>jQuery</li>
-        <li>Contributing to Node.js</li>
-        <li>More to come!</li>
-      </ul>
-
+      <p><strong>Are you on open source maintainer who would love more contributors to your project?</strong> Been itching to try mentoring? Please register at the event link above or reach out to us at <a href="mailto:us@empirejs.org" target="_top">us@empirejs.org</a>!</p>
 
     </div>
 
-    <div id="marquee-container" class="col-xs-12 col-sm-12 col-md-2 col-lg-2 col-xl-2">
-      <h3>7pm to 10pm</h3>
-      <p>OSS Night at Conde Nast</p>
-      <p>222 Broadway</p>
-      <p>New York, NY 10038</p>
+    <div id="venue-box" class="col-xs-12 col-sm-12 col-md-2 col-lg-2 col-xl-2">
+      <h3>May 25</h3>
+      <div>7pm to 10pm</div>
+      <div>Conde Nast</div>
+      <div>222 Broadway</div>
+      <div>New York, NY 10038</div>
     </div>
 
 </section>

--- a/views/partials/schedule.hbs
+++ b/views/partials/schedule.hbs
@@ -31,8 +31,8 @@
           <li class="event-schedule-item">
             <span class="event-schedule-dot"></span>
             <span class="event-schedule-item-time">7:00PM - 10:00PM</span>
-            <h4 class="event-schedule-item-title">Stay Tuned!</h4>
-            <p class="event-schedule-panel-desc"></p>
+            <h4 class="event-schedule-item-title">EmpireJS' Inaugural OSS Night!</h4>
+            <p class="event-schedule-panel-desc">Contribute to open source with your friends from EmpireJS at Conde Nast</p>
           </li>
 
           <li class="event-schedule-item event-schedule-header">


### PR DESCRIPTION
This adds the OSS Night copy and styling to 2016.empirejs.org including in the nav header, the schedule section, and a new partial `oss-night`. 
